### PR TITLE
Mark page as modified if page row was modified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "yarrd"
-version = "0.1.0"
+version = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarrd"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ General assumptions:
 - ✓ fix null ints not allowed
 - ✓ introduce query result struct instead of Row vec
 - ✓ think of extracting table row to separate class to incapsulate offset operations
-- introduce page alignment (may need to break down)
+- ✓ introduce page alignment (may need to break down)
   - ✓ create simple lru storage
   - ✓ read page from disk, flush page
   - ✓ use pager in table for read/write operations
   - ✓ track max rows to avoid getting deleted rows at the end of last page
-  - add flushed flag to page
+  - ✓ add flushed flag to page
 - think of bitwise version of cmp operator
 - use tempfile dir in command specs
 - extract page to separate file

--- a/src/database.rs
+++ b/src/database.rs
@@ -50,12 +50,7 @@ impl Database {
             .ok_or(MetaCommandError::SchemaDefinitionMissing)?;
         let mut column_definitions = vec![];
 
-        loop {
-            let column_name = match word_iter.next() {
-                Some(column_name) => column_name,
-                None => break,
-            };
-
+        while let Some(column_name) = word_iter.next() {
             let column_type_str = word_iter.next()
                 .ok_or(MetaCommandError::SchemaDefinitionInvalid {
                     table_name: table_name.to_string(),
@@ -78,7 +73,7 @@ impl Database {
                 kind: column_type
             });
         }
-        let table_filepath = Self::table_filepath(&tables_dir, table_name);
+        let table_filepath = Self::table_filepath(tables_dir, table_name);
 
         Ok(Table::new(table_filepath, table_name, column_definitions)?)
     }
@@ -114,7 +109,7 @@ impl Database {
 
     fn create_table(&mut self, table_name: SqlValue, columns: Vec<ColumnDefinition>) -> Result<Option<QueryResult>, ExecutionError> {
         let table_name_string = table_name.to_string();
-        let table_filepath = Self::table_filepath(&self.tables_dir.as_path(), table_name_string.as_str());
+        let table_filepath = Self::table_filepath(self.tables_dir.as_path(), table_name_string.as_str());
 
         if self.tables.contains_key(table_name_string.as_str()) {
             return Err(ExecutionError::TableAlreadyExist(table_name_string));
@@ -134,7 +129,7 @@ impl Database {
         match self.tables.remove(table_name_string.as_str()) {
             None => Err(ExecutionError::TableNotExist(table_name_string)),
             Some(_) => {
-                fs::remove_file(Self::table_filepath(&self.tables_dir.as_path(), table_name_string.as_str()))?;
+                fs::remove_file(Self::table_filepath(self.tables_dir.as_path(), table_name_string.as_str()))?;
                 Ok(None)
             },
         }

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -48,13 +48,14 @@ struct Page {
     bytes: [u8; PAGE_SIZE],
     row_size: usize,
     free_row_bitmask_size: usize,
+    modified: bool,
 }
 
 impl Page {
     pub fn new(row_size: usize, bytes: [u8; PAGE_SIZE]) -> Page {
         let row_count = Self::calculate_row_count(row_size);
         let free_row_bitmask_size = Self::free_row_bitmask_size(row_count);
-        Self { row_size, free_row_bitmask_size, bytes }
+        Self { row_size, free_row_bitmask_size, bytes, modified: false }
     }
 
     pub fn as_bytes(&self) -> &[u8] {
@@ -71,6 +72,7 @@ impl Page {
 
     pub fn delete_row(&mut self, page_row_number: usize) {
         self.flag_row_presence_status(page_row_number, false);
+        self.modified = true;
     }
 
     pub fn insert_row(&mut self, row: &Row) -> Result<(), PagerError> {
@@ -86,6 +88,7 @@ impl Page {
     pub fn update_row(&mut self, page_row_number: usize, row: &Row) {
         self.mut_row_bytes(page_row_number).copy_from_slice(row.as_bytes());
         self.flag_row_presence_status(page_row_number, true);
+        self.modified = true;
     }
 
     fn flag_row_presence_status(&mut self, page_row_number: usize, new_status: bool) {
@@ -244,6 +247,7 @@ impl Pager {
 
     fn flush(file: &mut File, page_data: Option<(u64, Page)>) -> Result<(), io::Error> {
         if let Some((page_id, page)) = page_data {
+            if !page.modified { return Ok(()) }
             file.seek(SeekFrom::Start(PAGE_SIZE as u64 * page_id))?;
             file.write_all(page.as_bytes())?;
         }
@@ -300,5 +304,21 @@ mod tests {
         assert_eq!(pager.get_row(1).unwrap().unwrap().as_bytes(), [71, 72, 73, 74, 75, 76, 77, 78]);
         assert!(pager.get_row(2).unwrap().is_none());
         assert_eq!(pager.get_row(504).unwrap().unwrap().as_bytes(), [63, 64, 65, 66, 67, 68, 69, 70]);
+    }
+
+    #[test]
+    fn page_flags_modifications() {
+        let table_file = TempFile::new("users.table").unwrap();
+        let mut contents = vec![0u8; PAGE_SIZE * 2];
+        table_file.write_bytes(&contents).unwrap();
+        let mut pager = Pager::new(table_file.path(), 8).unwrap();
+
+        assert_eq!(pager.get_page(0).unwrap().modified, false);
+        assert_eq!(pager.get_page(505).unwrap().modified, false); // 505th row is on the second page
+
+        pager.delete_row(5); // 5th row is on the 0th page
+
+        assert_eq!(pager.get_page(0).unwrap().modified, true);
+        assert_eq!(pager.get_page(505).unwrap().modified, false);
     }
 }

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -309,14 +309,14 @@ mod tests {
     #[test]
     fn page_flags_modifications() {
         let table_file = TempFile::new("users.table").unwrap();
-        let mut contents = vec![0u8; PAGE_SIZE * 2];
+        let contents = vec![0u8; PAGE_SIZE * 2];
         table_file.write_bytes(&contents).unwrap();
         let mut pager = Pager::new(table_file.path(), 8).unwrap();
 
         assert_eq!(pager.get_page(0).unwrap().modified, false);
         assert_eq!(pager.get_page(505).unwrap().modified, false); // 505th row is on the second page
 
-        pager.delete_row(5); // 5th row is on the 0th page
+        pager.delete_row(5).unwrap(); // 5th row is on the 0th page
 
         assert_eq!(pager.get_page(0).unwrap().modified, true);
         assert_eq!(pager.get_page(505).unwrap().modified, false);

--- a/src/pager/lru.rs
+++ b/src/pager/lru.rs
@@ -27,6 +27,9 @@ pub struct LinkedNode<K, V> {
     value: Option<V>,
 }
 
+type VecNodeIter<K, V> = std::vec::IntoIter<LinkedNode<K, V>>;
+type StripNodeFn<K, V> = fn(LinkedNode<K, V>) -> Option<(K, V)>;
+
 #[derive(Debug)]
 pub struct Lru<K, V> {
     key_location: HashMap<K, usize>,
@@ -140,7 +143,7 @@ impl<K: Eq + Hash + Copy, V> Lru<K, V> {
 
 impl<K, V> IntoIterator for Lru<K, V> {
     type Item = Option<(K, V)>;
-    type IntoIter = Map<std::vec::IntoIter<LinkedNode<K, V>>, fn(LinkedNode<K, V>) -> Self::Item>;
+    type IntoIter = Map<VecNodeIter<K, V>, StripNodeFn<K, V>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.use_sequence.into_iter().map(|node| {

--- a/src/table.rs
+++ b/src/table.rs
@@ -105,7 +105,7 @@ impl Table {
             for (i, column_index) in result_column_indices.iter().enumerate() {
                 let column_values_data = row.get_cell_bytes(&column_types, *column_index);
                 let column_is_null = row.cell_is_null(*column_index);
-                result_row.set_cell_bytes(&result_column_types, i, &column_values_data, column_is_null)?;
+                result_row.set_cell_bytes(&result_column_types, i, column_values_data, column_is_null)?;
             }
         }
 
@@ -169,7 +169,7 @@ impl Table {
         Ok(())
     }
 
-    fn matching_rows<'a>(&'a mut self, where_clause: Option<WhereClause>) -> impl Iterator<Item = Result<(u64, Row), ExecutionError>> + 'a {
+    fn matching_rows(&mut self, where_clause: Option<WhereClause>) -> impl Iterator<Item = Result<(u64, Row), ExecutionError>> + '_ {
         let where_filter = match where_clause {
             None => WhereFilter::dummy(),
             Some(where_clause) => where_clause.compile(&self.column_types[..], &self.name, &self.column_names),
@@ -190,7 +190,7 @@ impl Table {
         })
     }
 
-    fn seq_scan<'a>(pager: &'a mut Pager) -> impl Iterator<Item = (u64, Result<Row, PagerError>)> + 'a {
+    fn seq_scan(pager: &mut Pager) -> impl Iterator<Item = (u64, Result<Row, PagerError>)> + '_ {
         let max_rows = pager.max_rows();
         (0..max_rows).map(|row_number| (row_number, pager.get_row(row_number)))
             .filter(|(_row_number, row_check)| row_check.is_err() || row_check.as_ref().unwrap().is_some())


### PR DESCRIPTION
- whenever page updates a row, it marks itself as modified;
- if `flush` is called on page, it won't write to a disk if page was not modified;
- fix some clippy warnings.