### PR TITLE
Add row hard size limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "yarrd"
-version = "0.1.2"
+version = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarrd"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ All strings stored with fixed 256 bytes alignment, that's why there is bunch of 
 - ✓ add is Null check
 - ✓ remove result from where closures, cmp should return false in case of undefined, or think of three-valued logic
 - ✓ refactor cmp_operator a bit
-- add hard limit to row size
+- ✓ add hard limit to row size
 - float values
 - think of bitwise version of cmp operator
 - think of table error or table init error

--- a/src/row.rs
+++ b/src/row.rs
@@ -1,43 +1,17 @@
-use std::cmp::Ordering;
-
 use crate::table::ColumnType;
 use crate::serialize::{deserialize, serialize_into, SerDeError};
 use crate::execution_error::ExecutionError;
 use crate::lexer::SqlValue;
+use byte_layout::ByteLayout;
+
+mod byte_layout;
 
 pub const INTEGER_SIZE: usize = 8;
 pub const STRING_SIZE: usize = 256;
 
-#[derive(Debug)]
-struct ByteLayout {
-    columns_offsets: Vec<usize>,
-    row_size: usize,
-}
-
-impl ByteLayout {
-    fn null_bitmask_byte_size(&self) -> usize {
-        match self.columns_offsets.len() {
-            0 => 0,
-            _ => self.columns_offsets[0],
-        }
-    }
-
-    fn column_size(&self, index: usize) -> usize {
-        let max_index = self.columns_offsets.len() - 1;
-        match index.cmp(&max_index) {
-            Ordering::Equal => self.row_size - self.columns_offsets[max_index],
-            Ordering::Less => self.columns_offsets[index + 1] - self.columns_offsets[index],
-            Ordering::Greater => {
-                panic!("index is out of bounds, cannot get column with index {} when there are only {} columns",
-                       index, self.columns_offsets.len())
-            }
-        }
-    }
-}
-
 /// Struct for manipulating with row's bytes, and spawning its interpretation.
 /// Is it simple, so it does not check if provided bytes match column types,
-/// and that source have correct byte size to read - this all table's responsibility.
+/// and that source has correct byte size to read - this all table's responsibility.
 
 #[derive(Debug)]
 pub struct Row {
@@ -108,13 +82,6 @@ impl Row {
         &self.bytes[offset..(offset + cell_size)]
     }
 
-    //fn get_cell_bytes_mut(&mut self, column_types: &[ColumnType], column_index: usize) -> &mut [u8] {
-    //    let layout = Self::generate_byte_layout(column_types);
-    //    let offset = layout.columns_offsets[column_index];
-    //    let cell_size = layout.column_size(column_index);
-    //    &mut self.bytes[offset..(offset + cell_size)]
-    //}
-
     pub fn get_cell_sql_value(&self, column_types: &[ColumnType], column_index: usize) -> Result<SqlValue, ExecutionError> {
         if self.cell_is_null(column_index) {
             Ok(SqlValue::Null)
@@ -144,12 +111,6 @@ impl Row {
         &self.bytes[..]
     }
 
-    //fn column_offset(&self, column_index: usize) -> usize {
-    //    self.null_bitmask_size() +
-    //        (0..column_index).fold(0, |total_size, i| total_size + Self::column_size(self.column_types[i]))
-    //        // TODO: use sum
-    //}
-
     fn column_size(column_type: ColumnType) -> usize {
         match column_type {
             ColumnType::Integer => INTEGER_SIZE,
@@ -157,33 +118,17 @@ impl Row {
         }
     }
 
-    // pub fn row_size(&self) -> usize {
-    //     self.bytes.len()
-    //         // Self::calculate_row_size(self.column_types)
-    // }
-
     pub fn cell_is_null(&self, column_index: usize) -> bool {
         self.bytes[column_index / 8] & (1 << (column_index % 8)) != 0
     }
 
     pub fn calculate_row_size(column_types: &[ColumnType]) -> usize {
         Self::generate_byte_layout(column_types).row_size
-        //Self::calculate_null_bitmask_size(column_types.len()) +
-        //    column_types.iter().map(|ct| Self::column_size(*ct)).sum::<usize>()
-
     }
-
-    //fn null_bitmask_size(&self) -> usize {
-    //    Self::calculate_null_bitmask_size(self.column_types.len())
-    //}
 
     fn calculate_null_bitmask_size(columns_len: usize) -> usize {
         (columns_len + 7) / 8
     }
-
-    //fn null_bitmask(&self) -> &[u8] {
-    //    &self.bytes[0..self.null_bitmask_size()]
-    //}
 
     fn nullify_cell(&mut self, column_index: usize) {
         self.bytes[column_index / 8] |= 1 << (column_index % 8);
@@ -192,7 +137,6 @@ impl Row {
     fn denullify_cell(&mut self, column_index: usize) {
         self.bytes[column_index / 8] &= !(1 << (column_index % 8));
     }
-
 
     //pub fn get<'a, T: From<&'a SqlValue>>(&self, index: usize) -> Result<T, String> {
     //    let value = self.column_values.get(index)

--- a/src/row/byte_layout.rs
+++ b/src/row/byte_layout.rs
@@ -1,0 +1,28 @@
+use std::cmp::Ordering;
+
+#[derive(Debug)]
+pub struct ByteLayout {
+    pub columns_offsets: Vec<usize>,
+    pub row_size: usize,
+}
+
+impl ByteLayout {
+    pub fn null_bitmask_byte_size(&self) -> usize {
+        match self.columns_offsets.len() {
+            0 => 0,
+            _ => self.columns_offsets[0],
+        }
+    }
+
+    pub fn column_size(&self, index: usize) -> usize {
+        let max_index = self.columns_offsets.len() - 1;
+        match index.cmp(&max_index) {
+            Ordering::Equal => self.row_size - self.columns_offsets[max_index],
+            Ordering::Less => self.columns_offsets[index + 1] - self.columns_offsets[index],
+            Ordering::Greater => {
+                panic!("index is out of bounds, cannot get column with index {} when there are only {} columns",
+                       index, self.columns_offsets.len())
+            }
+        }
+    }
+}


### PR DESCRIPTION
Page is 4096 bytes, and currently there is no mechanism to spread single row over multiple pages. This PR prevents from creating tables which rows won't fit the page.