### PR TITLE
feat: execute rename table statement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "yarrd"
-version = "0.1.9"
+version = "0.1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarrd"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ All strings stored with fixed 256 bytes alignment, that's why there is bunch of 
   - ✓ add column
   - ✓ drop column
 - alter table execution
-  - rename table
+  - ✓ rename table
   - rename column
   - add column
   - drop column

--- a/src/command.rs
+++ b/src/command.rs
@@ -270,6 +270,29 @@ mod tests {
         assert_eq!(select_rows.len(), 0);
     }
 
+    #[test]
+    fn create_and_rename_table() {
+        let (_db_file, mut database) = open_test_database();
+        let create_table = Command::CreateTable {
+            table_name: SqlValue::Identificator("users".to_string()),
+            columns: vec![
+                ColumnDefinition {
+                    name: SqlValue::Identificator("id".to_string()),
+                    kind: ColumnType::Integer,
+                },
+            ],
+        };
+
+        assert!(database.execute(create_table).is_ok());
+
+        let rename_table = Command::RenameTable {
+            table_name: SqlValue::Identificator("users".to_string()),
+            new_table_name: SqlValue::Identificator("users_new".to_string()),
+        };
+
+        assert!(database.execute(rename_table).is_ok());
+    }
+
     fn open_test_database() -> (TempFile, Database) {
         let db_file = TempFile::new("database.db").unwrap();
         let temp_dir_path = db_file.temp_dir_path.to_str().unwrap();


### PR DESCRIPTION
it is now possible to rename tables with
`ALTER TABLE  table_name RENAME TO new_table_name`