### PR TITLE
Feat/createdb dropdb command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "yarrd"
-version = "0.1.14"
+version = "0.1.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarrd"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ All strings stored with fixed 256 bytes alignment, that's why there is bunch of 
 - ✓ implement vacuum metacommand or something like that
 - ✓ add .create/.drop metacommand
 - add .connect/.close metacommands
+- add metacommands docs
 - implement primary constraint (may be just a primary key flag, no general constraints)
 - add row_id
 - introduce NOT

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ All strings stored with fixed 256 bytes alignment, that's why there is bunch of 
 - allow to store strings with top limit less than 255 symbols (which will take less space)
 - think of calculating row cell offset via null bitmask, so null cells won't occupy space on disk
 - WAL
+- think of adding "cascade" file manager to easily rollback changes if failed on some step
 - handle errors on db close and flush
 - restore from journal
 - transactions
+- think of metalexer

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ All strings stored with fixed 256 bytes alignment, that's why there is bunch of 
   - ✓ add column
   - ✓ drop column
 - ✓ implement vacuum metacommand or something like that
-- add .create/.drop metacommand
+- ✓ add .create/.drop metacommand
 - add .connect/.close metacommands
 - implement primary constraint (may be just a primary key flag, no general constraints)
 - add row_id

--- a/src/command.rs
+++ b/src/command.rs
@@ -2,10 +2,6 @@ use crate::table::ColumnType;
 use crate::lexer::SqlValue;
 use crate::where_clause::WhereClause;
 
-pub enum MetaCommand {
-    Exit,
-}
-
 #[derive(Debug)]
 pub enum SelectColumnName {
     Name(SqlValue),

--- a/src/database.rs
+++ b/src/database.rs
@@ -73,7 +73,7 @@ impl Database {
             }
         }
 
-        write!(database_file, "{}\n", tables_dir.into_os_string().into_string().unwrap());
+        writeln!(database_file, "{}", tables_dir.into_os_string().into_string().unwrap());
         // ideally we should check if it is succesfull, should handle in "cascade" file
         // manager
 
@@ -84,7 +84,7 @@ impl Database {
         let mut database = Self::from(database_filepath)?;
         let mut table_names = vec![];
 
-        for (table_name, _table) in &database.tables {
+        for table_name in database.tables.keys() {
             table_names.push(SqlValue::Identificator(table_name.to_string()));
         }
         for table_name in table_names {

--- a/src/database.rs
+++ b/src/database.rs
@@ -48,17 +48,14 @@ impl Database {
     pub fn create(database_filepath: &Path, tables_dir_path: &Path) -> Result<(), MetaCommandError> {
         let tables_dir = PathBuf::from(tables_dir_path);
         let database_filepath = PathBuf::from(database_filepath);
-        let mut need_to_create_tables_dir = true;
 
         if database_filepath.exists() {
             return Err(MetaCommandError::DatabaseFileAlreadyExist(database_filepath));
-        } else if tables_dir.exists() {
-            need_to_create_tables_dir = false;
         }
 
         let mut database_file = File::create(database_filepath.clone())?;
 
-        if need_to_create_tables_dir {
+        if !tables_dir.exists() {
             match fs::create_dir(tables_dir.clone()) {
                 Err(create_tables_dir_error) => {
                     fs::remove_file(database_filepath.as_path())

--- a/src/database.rs
+++ b/src/database.rs
@@ -80,6 +80,21 @@ impl Database {
         Ok(())
     }
 
+    pub fn drop(database_filepath: &Path) -> Result<(), MetaCommandError> {
+        let mut database = Self::from(database_filepath)?;
+        let mut table_names = vec![];
+
+        for (table_name, _table) in &database.tables {
+            table_names.push(SqlValue::Identificator(table_name.to_string()));
+        }
+        for table_name in table_names {
+            database.drop_table(table_name).map_err(MetaCommandError::ExecutionError)?;
+        }
+
+        fs::remove_file(database_filepath).map_err(MetaCommandError::IoError)?;
+        Ok(())
+    }
+
     fn parse_schema_line(tables_dir: &Path, table_definition_line: &str) -> Result<Table, MetaCommandError> {
         let mut word_iter = table_definition_line.split_whitespace();
         let table_name = word_iter.next()

--- a/src/database.rs
+++ b/src/database.rs
@@ -91,6 +91,7 @@ impl Database {
             database.drop_table(table_name).map_err(MetaCommandError::ExecutionError)?;
         }
 
+        // TODO: use cascade file manager to panic from unrecoverable errors with correct message
         fs::remove_file(database_filepath).map_err(MetaCommandError::IoError)?;
         Ok(())
     }

--- a/src/database.rs
+++ b/src/database.rs
@@ -73,7 +73,7 @@ impl Database {
             }
         }
 
-        writeln!(database_file, "{}", tables_dir.into_os_string().into_string().unwrap());
+        writeln!(database_file, "{}", tables_dir.display())?;
         // ideally we should check if it is succesfull, should handle in "cascade" file
         // manager
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,29 +55,31 @@ fn run() -> Result<(), MetaCommandError> {
                 println!("error executing meta command: {}", error);
                 continue
             },
-            MetaCommandResult::None => {
-                let tokens = match lexer::to_tokens(input) {
-                    Ok(tokens) => tokens,
-                    Err(message) => {
-                        println!("cannot parse statement: {}", message);
-                        continue
-                    },
-                };
-
-                match parser::parse_statement(tokens.iter()) {
-                    Err(error) => println!("error parsing statement: {}", error),
-                    Ok(command) => {
-                        match database.execute(command) {
-                            Ok(result) => println!("{:?}", result),
-                            Err(message) => println!("cannot execute statement: {}", message),
-                        }
-                    },
-                }
-            },
+            MetaCommandResult::None => parse_and_execute_sql_statement(input, &mut database),
         };
     };
     database.close();
     Ok(())
+}
+
+fn parse_and_execute_sql_statement(input: &str, database: &mut Database) {
+    let tokens = match lexer::to_tokens(input) {
+        Ok(tokens) => tokens,
+        Err(message) => {
+            println!("cannot parse statement: {}", message);
+            return
+        },
+    };
+
+    match parser::parse_statement(tokens.iter()) {
+        Err(error) => println!("error parsing statement: {}", error),
+        Ok(command) => {
+            match database.execute(command) {
+                Ok(result) => println!("{:?}", result),
+                Err(message) => println!("cannot execute statement: {}", message),
+            }
+        },
+    }
 }
 
 fn print_prompt() {

--- a/src/meta_command.rs
+++ b/src/meta_command.rs
@@ -18,7 +18,7 @@ impl MetaCommand {
             Self::Void => MetaCommandResult::None,
             Self::Exit => MetaCommandResult::Exit,
             Self::MetacommandWithWrongArgs(error) => MetaCommandResult::Err(error),
-            Self::Unknown(input) => MetaCommandResult::Err(MetaCommandError::UnknownCommand(input.to_string())),
+            Self::Unknown(input) => MetaCommandResult::Err(MetaCommandError::UnknownCommand(input)),
             Self::Createdb { db_path, tables_dir_path } => {
                 match Database::create(&db_path, &tables_dir_path) {
                     Ok(()) => MetaCommandResult::Ok,

--- a/src/meta_command.rs
+++ b/src/meta_command.rs
@@ -1,0 +1,68 @@
+use crate::database::Database;
+use crate::meta_command_error::MetaCommandError;
+
+use std::path::PathBuf;
+
+pub enum MetaCommand {
+    Void,
+    Unknown(String),
+    MetacommandWithWrongArgs(MetaCommandError),
+    Exit,
+    Createdb { db_path: PathBuf, tables_dir_path: PathBuf },
+}
+
+impl MetaCommand {
+    pub fn execute(self) -> MetaCommandResult {
+        match self {
+            Self::Void => MetaCommandResult::None,
+            Self::Exit => MetaCommandResult::Exit,
+            Self::MetacommandWithWrongArgs(error) => MetaCommandResult::Err(error),
+            Self::Unknown(input) => MetaCommandResult::Err(MetaCommandError::UnknownCommand(input.to_string())),
+            Self::Createdb { db_path, tables_dir_path } => {
+                match Database::create(&db_path, &tables_dir_path) {
+                    Ok(()) => MetaCommandResult::Ok,
+                    Err(error) => MetaCommandResult::Err(error),
+                }
+            }
+        }
+    }
+}
+
+pub enum MetaCommandResult {
+    Ok,
+    None,
+    Exit,
+    Err(MetaCommandError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::temp_file::TempFile;
+
+    #[test]
+    fn create_database() {
+        let (temp_dir, _temp_file) = create_temp_dir();
+
+        let create_database = MetaCommand::Createdb {
+            db_path: PathBuf::from(format!("{}/new_db", temp_dir.to_str().unwrap())),
+            tables_dir_path: PathBuf::from(format!("{}/some_tables", temp_dir.to_str().unwrap())),
+        };
+
+        assert!(matches!(create_database.execute(), MetaCommandResult::Ok));
+
+        let create_database = MetaCommand::Createdb {
+            db_path: PathBuf::from(format!("{}/another_new_db", temp_dir.to_str().unwrap())),
+            tables_dir_path: temp_dir,
+        };
+
+        assert!(matches!(create_database.execute(), MetaCommandResult::Ok));
+    }
+
+    fn create_temp_dir() -> (PathBuf, TempFile) {
+        let db_file = TempFile::new("dummy").unwrap();
+        let temp_dir_path = db_file.temp_dir_path.clone();
+        // we need to return tempfile because it will be dropped and removed otherwise
+        (temp_dir_path, db_file)
+    }
+}

--- a/src/meta_command_error.rs
+++ b/src/meta_command_error.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::path::PathBuf;
 
 use crate::table::error::TableError;
+use crate::execution_error::ExecutionError;
 
 #[derive(Debug)]
 pub enum MetaCommandError {
@@ -15,6 +16,7 @@ pub enum MetaCommandError {
     TableError(TableError),
     ParseError(String),
     UnknownCommand(String),
+    ExecutionError(ExecutionError),
 }
 
 impl fmt::Display for MetaCommandError {
@@ -34,6 +36,7 @@ impl fmt::Display for MetaCommandError {
             Self::TableError(table_error) => table_error.to_string(),
             Self::ParseError(parser_error) => format!("failed to parse metacommand: {}", parser_error),
             Self::UnknownCommand(input) => format!("unknown metacommand: {}", input),
+            Self::ExecutionError(exec_error) => format!("failed to execute metacommand: {}", exec_error),
         };
         write!(f, "{}", message)
     }

--- a/src/meta_command_error.rs
+++ b/src/meta_command_error.rs
@@ -8,10 +8,13 @@ use crate::table::error::TableError;
 #[derive(Debug)]
 pub enum MetaCommandError {
     IoError(io::Error),
+    DatabaseFileAlreadyExist(PathBuf),
     DatabaseTablesDirNotExist(PathBuf),
     SchemaDefinitionMissing,
     SchemaDefinitionInvalid { table_name: String, expected: &'static str, actual: String },
     TableError(TableError),
+    ParseError(String),
+    UnknownCommand(String),
 }
 
 impl fmt::Display for MetaCommandError {
@@ -21,11 +24,16 @@ impl fmt::Display for MetaCommandError {
             Self::DatabaseTablesDirNotExist(tables_dir) =>
                 format!("database file specified '{}' as a tables dir, but it does not exist",
                         tables_dir.to_str().unwrap()),
+            Self::DatabaseFileAlreadyExist(tables_dir) =>
+                format!("cannot create database file at '{}': file already exist",
+                        tables_dir.to_str().unwrap()),
             Self::SchemaDefinitionMissing => "no schema definition found".to_string(),
             Self::SchemaDefinitionInvalid { table_name, expected, actual } =>
                 format!("failed to parse schema definition for table '{}', expected {}, got '{}'",
                         table_name, expected, actual),
             Self::TableError(table_error) => table_error.to_string(),
+            Self::ParseError(parser_error) => format!("failed to parse metacommand: {}", parser_error),
+            Self::UnknownCommand(input) => format!("unknown metacommand: {}", input),
         };
         write!(f, "{}", message)
     }

--- a/src/pager/lru.rs
+++ b/src/pager/lru.rs
@@ -56,6 +56,7 @@ impl<K: Eq + Hash + Copy, V> Lru<K, V> {
         Ok(Lru { use_sequence, key_location, current: 0 })
     }
 
+    #[allow(dead_code)]
     pub fn get(&mut self, key: &K) -> Option<&V> {
         match self.key_location.get(key) {
             Some(&key_index) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -339,57 +339,32 @@ mod tests {
 
     #[test]
     fn createdb() {
+        let valid_expectations = vec![
+            (".createdb foo", ("./foo", "./foo_tables")),
+            (".createdb foo ./bar", ("./foo", "./bar")),
+            (".createdb ./some_path/foo ./foo/bar", ("./some_path/foo", "./foo/bar")),
+            (".createdb foo bar", ("./foo", "./bar")),
+            (".createdb .foo /some_path/bar", ("./.foo", "/some_path/bar")),
+            (".createdb /some_abs_path/foo bar", ("/some_abs_path/foo", "./bar")),
+        ];
+
         assert!(matches!(
                     parse_meta_command(".createdb"),
                     MetaCommand::MetacommandWithWrongArgs(MetaCommandError::ParseError(_))
                 ));
 
-        match parse_meta_command(".createdb foo") {
-            MetaCommand::Createdb { db_path, tables_dir_path } => {
-                assert_eq!(db_path, PathBuf::from("./foo"));
-                assert_eq!(tables_dir_path, PathBuf::from("./foo_tables"));
-            },
-            _ => panic!("Expected '.createdb foo' to be parsed to Createdb"),
+        for expectation in valid_expectations {
+            assert_createdb(expectation.0, expectation.1.0, expectation.1.1)
         }
+    }
 
-        match parse_meta_command(".createdb foo ./bar") {
+    fn assert_createdb(input: &str, metacommand_db_path: &str, metacommand_tables_dir_path: &str) {
+        match parse_meta_command(input) {
             MetaCommand::Createdb { db_path, tables_dir_path } => {
-                assert_eq!(db_path, PathBuf::from("./foo"));
-                assert_eq!(tables_dir_path, PathBuf::from("./bar"));
+                assert_eq!(db_path, PathBuf::from(metacommand_db_path));
+                assert_eq!(tables_dir_path, PathBuf::from(metacommand_tables_dir_path));
             },
-            _ => panic!("Expected '.createdb foo' to be parsed to Createdb"),
-        }
-
-        match parse_meta_command(".createdb ./some_path/foo ./foo/bar") {
-            MetaCommand::Createdb { db_path, tables_dir_path } => {
-                assert_eq!(db_path, PathBuf::from("./some_path/foo"));
-                assert_eq!(tables_dir_path, PathBuf::from("./foo/bar"));
-            },
-            _ => panic!("Expected '.createdb foo' to be parsed to Createdb"),
-        }
-
-        match parse_meta_command(".createdb foo bar") {
-            MetaCommand::Createdb { db_path, tables_dir_path } => {
-                assert_eq!(db_path, PathBuf::from("./foo"));
-                assert_eq!(tables_dir_path, PathBuf::from("./bar"));
-            },
-            _ => panic!("Expected '.createdb foo' to be parsed to Createdb"),
-        }
-
-        match parse_meta_command(".createdb .foo /some_path/bar") {
-            MetaCommand::Createdb { db_path, tables_dir_path } => {
-                assert_eq!(db_path, PathBuf::from("./.foo"));
-                assert_eq!(tables_dir_path, PathBuf::from("/some_path/bar"));
-            },
-            _ => panic!("Expected '.createdb foo' to be parsed to Createdb"),
-        }
-
-        match parse_meta_command(".createdb /some_abs_path/foo bar") {
-            MetaCommand::Createdb { db_path, tables_dir_path } => {
-                assert_eq!(db_path, PathBuf::from("/some_abs_path/foo"));
-                assert_eq!(tables_dir_path, PathBuf::from("./bar"));
-            },
-            _ => panic!("Expected '.createdb foo' to be parsed to Createdb"),
+            _ => panic!("Expected '{}' to be parsed to Createdb", input),
         }
     }
 

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -6,7 +6,7 @@ use crate::parser::Token;
 #[derive(Debug)]
 pub enum ParserError<'a> {
     UnknownCommand(&'a Token),
-    UnknownMetaCommand(&'a str),
+    DatabaseNameMissing,
     ExcessTokens(Vec<&'a Token>),
     CreateTypeMissing,
     CreateTypeUnknown(&'a Token),
@@ -59,7 +59,7 @@ impl<'a> fmt::Display for ParserError<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let message = match self {
             Self::UnknownCommand(command) => format!("unknown command '{}'", command),
-            Self::UnknownMetaCommand(command) => format!("unknown meta command '{}'", command),
+            Self::DatabaseNameMissing => "database name is not provided".to_string(),
             Self::ExcessTokens(tokens) =>
                 format!("statement is correct, but contains excess tokens {:?}",
                         tokens.iter().map(|t| t.to_string()).collect::<Vec<String>>()),

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -7,6 +7,7 @@ use crate::parser::Token;
 pub enum ParserError<'a> {
     UnknownCommand(&'a Token),
     DatabaseNameMissing,
+    CouldNotParseDbFilename(&'a str),
     ExcessTokens(Vec<&'a Token>),
     CreateTypeMissing,
     CreateTypeUnknown(&'a Token),
@@ -60,6 +61,8 @@ impl<'a> fmt::Display for ParserError<'a> {
         let message = match self {
             Self::UnknownCommand(command) => format!("unknown command '{}'", command),
             Self::DatabaseNameMissing => "database name is not provided".to_string(),
+            Self::CouldNotParseDbFilename(full_path_buf) =>
+                format!("could not extract database filename from {}", full_path_buf),
             Self::ExcessTokens(tokens) =>
                 format!("statement is correct, but contains excess tokens {:?}",
                         tokens.iter().map(|t| t.to_string()).collect::<Vec<String>>()),

--- a/src/query_result.rs
+++ b/src/query_result.rs
@@ -19,6 +19,7 @@ impl QueryResult {
         self.rows.last_mut().unwrap()
     }
 
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.rows.len()
     }


### PR DESCRIPTION
Add metacommands for creating and dropping databases:
`.createdb database_name [path_to_dir_for_tables_files]`
`.dropdb database_name`

Examples:
`.createdb application_test`
`.createdb application_dev ./dev`
`.dropdb application_test`