### PR TITLE
Allow to update constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "yarrd"
-version = "0.2.0"
+version = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarrd"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Supported constraints: `NOT NULL`.
 - ✓ add metacommands docs
 - ✗ add row_id to service bytes
 - ✓ implement not null constraint
-- allow to update constraints
+- ✓ allow to update constraints
 - implement default constraint
 - implement check constraint
 - implement create index

--- a/src/command.rs
+++ b/src/command.rs
@@ -304,7 +304,7 @@ mod tests {
     }
 
     #[test]
-    fn create_and_rename_table() {
+    fn create_and_rename_alter_constraint_table() {
         let (_db_file, mut database) = open_test_database();
         let create_table = Command::CreateTable {
             table_name: SqlValue::Identificator("users".to_string()),
@@ -325,6 +325,22 @@ mod tests {
         };
 
         assert!(database.execute(rename_table).is_ok());
+
+        let alter_table_constraint = Command::AddColumnConstraint {
+            table_name: SqlValue::Identificator("users_new".to_string()),
+            column_name: SqlValue::Identificator("id".to_string()),
+            constraint: Constraint::NotNull
+        };
+
+        assert!(database.execute(alter_table_constraint).is_ok());
+
+        let drop_table_constraint = Command::DropColumnConstraint {
+            table_name: SqlValue::Identificator("users_new".to_string()),
+            column_name: SqlValue::Identificator("id".to_string()),
+            constraint: Constraint::NotNull
+        };
+
+        assert!(database.execute(drop_table_constraint).is_ok());
     }
 
     #[test]

--- a/src/command.rs
+++ b/src/command.rs
@@ -67,6 +67,11 @@ pub enum Command {
         column_name: SqlValue,
         constraint: Constraint,
     },
+    DropColumnConstraint {
+        table_name: SqlValue,
+        column_name: SqlValue,
+        constraint: Constraint,
+    },
     DropTableColumn {
         table_name: SqlValue,
         column_name: SqlValue,

--- a/src/command.rs
+++ b/src/command.rs
@@ -62,6 +62,11 @@ pub enum Command {
         table_name: SqlValue,
         column_definition: ColumnDefinition,
     },
+    AddColumnConstraint {
+        table_name: SqlValue,
+        column_name: SqlValue,
+        constraint: Constraint,
+    },
     DropTableColumn {
         table_name: SqlValue,
         column_name: SqlValue,

--- a/src/database.rs
+++ b/src/database.rs
@@ -143,6 +143,7 @@ impl Database {
             Command::RenameTableColumn { table_name, column_name, new_column_name } =>
                 self.rename_table_column(table_name, column_name, new_column_name),
             Command::AddTableColumn { table_name, column_definition } => self.add_table_column(table_name, column_definition),
+            Command::AddColumnConstraint { table_name, column_name, constraint } => {Ok(None)},
             Command::DropTableColumn { table_name, column_name } => self.drop_table_column(table_name, column_name),
             Command::VacuumTable { table_name } => self.vacuum_table(&table_name),
             Command::Void => Ok(None),

--- a/src/database.rs
+++ b/src/database.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use crate::command::{Command, ColumnDefinition, FieldAssignment, SelectColumnName};
 use crate::where_clause::WhereClause;
 use crate::lexer::SqlValue;
-use crate::table::{Table, ColumnType};
+use crate::table::{Table, ColumnType, Constraint};
 use crate::execution_error::ExecutionError;
 use crate::meta_command_error::MetaCommandError;
 use crate::query_result::QueryResult;
@@ -143,8 +143,10 @@ impl Database {
             Command::RenameTableColumn { table_name, column_name, new_column_name } =>
                 self.rename_table_column(table_name, column_name, new_column_name),
             Command::AddTableColumn { table_name, column_definition } => self.add_table_column(table_name, column_definition),
-            Command::AddColumnConstraint { table_name, column_name, constraint } => { Ok(None) },
-            Command::DropColumnConstraint { table_name, column_name, constraint } => { Ok(None) },
+            Command::AddColumnConstraint { table_name, column_name, constraint } =>
+                self.add_table_column_constraint(table_name, column_name, constraint),
+            Command::DropColumnConstraint { table_name, column_name, constraint } =>
+                self.drop_table_column_constraint(table_name, column_name, constraint),
             Command::DropTableColumn { table_name, column_name } => self.drop_table_column(table_name, column_name),
             Command::VacuumTable { table_name } => self.vacuum_table(&table_name),
             Command::Void => Ok(None),
@@ -250,6 +252,28 @@ impl Database {
 
         let table = self.get_table(&table_name)?;
         table.rename_column(column_name_string, new_column_name_string)?;
+
+        // TODO: use result, and rename column back if flush is not possible
+        self.flush_schema();
+        Ok(None)
+    }
+
+    fn add_table_column_constraint(&mut self, table_name: SqlValue, column_name: SqlValue, constraint: Constraint) -> Result<Option<QueryResult>, ExecutionError> {
+        let column_name_string = column_name.to_string();
+
+        let table = self.get_table(&table_name)?;
+        table.add_column_constraint(column_name_string, constraint)?;
+
+        // TODO: use result, and rename column back if flush is not possible
+        self.flush_schema();
+        Ok(None)
+    }
+
+    fn drop_table_column_constraint(&mut self, table_name: SqlValue, column_name: SqlValue, constraint: Constraint) -> Result<Option<QueryResult>, ExecutionError> {
+        let column_name_string = column_name.to_string();
+
+        let table = self.get_table(&table_name)?;
+        table.drop_column_constraint(column_name_string, constraint)?;
 
         // TODO: use result, and rename column back if flush is not possible
         self.flush_schema();

--- a/src/database.rs
+++ b/src/database.rs
@@ -143,7 +143,8 @@ impl Database {
             Command::RenameTableColumn { table_name, column_name, new_column_name } =>
                 self.rename_table_column(table_name, column_name, new_column_name),
             Command::AddTableColumn { table_name, column_definition } => self.add_table_column(table_name, column_definition),
-            Command::AddColumnConstraint { table_name, column_name, constraint } => {Ok(None)},
+            Command::AddColumnConstraint { table_name, column_name, constraint } => { Ok(None) },
+            Command::DropColumnConstraint { table_name, column_name, constraint } => { Ok(None) },
             Command::DropTableColumn { table_name, column_name } => self.drop_table_column(table_name, column_name),
             Command::VacuumTable { table_name } => self.vacuum_table(&table_name),
             Command::Void => Ok(None),

--- a/src/database.rs
+++ b/src/database.rs
@@ -229,7 +229,7 @@ impl Database {
         let table_filepath = Self::table_filepath(self.tables_dir.as_path(), table_name_string.as_str());
         let new_table_filepath = Self::table_filepath(self.tables_dir.as_path(), new_table_name_string.as_str());
 
-        let table = match self.tables.remove(table_name_string.as_str()) {
+        let mut table = match self.tables.remove(table_name_string.as_str()) {
             None => return Err(ExecutionError::TableNotExist(table_name_string)),
             Some(table) => table,
         };
@@ -240,6 +240,7 @@ impl Database {
                 Err(io_error.into())
             },
             Ok(_) => {
+                table.name = new_table_name_string.clone();
                 self.tables.insert(new_table_name_string, table);
                 Ok(None)
             }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -32,6 +32,7 @@ pub enum Token {
     Values,
     Is,
     Not,
+    Constraint,
     Vacuum,
     IntegerType, // TODO: maybe extract types to separate enum
     StringType,
@@ -73,6 +74,7 @@ impl fmt::Display for Token {
             Self::Is => "IS",
             Self::Not => "NOT",
             Self::Vacuum => "VACUUM",
+            Self::Constraint => "CONSTRAINT",
             Self::IntegerType => "int",
             Self::StringType => "string",
             Self::FloatType => "float",
@@ -209,6 +211,7 @@ fn parse_token(str_token: &str) -> Token {
         "is" => Token::Is,
         "not" => Token::Not,
         "vacuum" => Token::Vacuum,
+        "constraint" => Token::Constraint,
         "int" => Token::IntegerType,
         "float" => Token::FloatType,
         "string" => Token::StringType,
@@ -266,7 +269,7 @@ mod tests {
 
     #[test]
     fn token_qoutes_parse() {
-        let valid_input = "CrEAte vacuum (row NULL \"column, type\" int -421 string 43.2552 \" ; \"";
+        let valid_input = "CrEAte vacuum (row NULL \"column, type\" constraint int -421 string 43.2552 \" ; \"";
 
         assert!(to_tokens(valid_input).is_ok());
         assert_eq!(
@@ -274,7 +277,7 @@ mod tests {
             vec![
                 Token::Create, Token::Vacuum, Token::LeftParenthesis, Token::Value(SqlValue::Identificator("row".into())),
                 Token::Value(SqlValue::Null), Token::Value(SqlValue::String("column, type".to_string())),
-                Token::IntegerType, Token::Value(SqlValue::Integer(-421)), Token::StringType,
+                Token::Constraint, Token::IntegerType, Token::Value(SqlValue::Integer(-421)), Token::StringType,
                 Token::Value(SqlValue::Float(43.2552)), Token::Value(SqlValue::String(" ; ".into()))
             ]
         )

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -309,6 +309,20 @@ mod tests {
     }
 
     #[test]
+    fn alter_add_constraint() {
+        let input = vec![
+                Token::Alter, Token::Table,
+                Token::Value(SqlValue::Identificator("table_name".into())),
+                Token::Add, Token::Constraint, Token::Not, Token::Value(SqlValue::Null),
+                Token::LeftParenthesis,
+                Token::Value(SqlValue::Identificator("id".into())),
+                Token::RightParenthesis,
+           ];
+
+        assert!(parse_statement(input.iter()).is_ok());
+    }
+
+    #[test]
     fn alter_rename_table_column() {
         let input = vec![
                 Token::Alter, Token::Table,
@@ -327,7 +341,7 @@ mod tests {
         let input = vec![
                 Token::Alter, Token::Table,
                 Token::Value(SqlValue::Identificator("table_name".into())),
-                Token::Add, Token::Value(SqlValue::Identificator("column_name".into())),
+                Token::Add, Token::Column, Token::Value(SqlValue::Identificator("column_name".into())),
                 Token::IntegerType,
            ];
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -361,6 +361,20 @@ mod tests {
     }
 
     #[test]
+    fn alter_table_drop_constraint() {
+        let input = vec![
+                Token::Alter, Token::Table,
+                Token::Value(SqlValue::Identificator("table_name".into())),
+                Token::Drop, Token::Constraint, Token::Not, Token::Value(SqlValue::Null),
+                Token::LeftParenthesis,
+                Token::Value(SqlValue::Identificator("id".into())),
+                Token::RightParenthesis,
+           ];
+
+        assert!(parse_statement(input.iter()).is_ok());
+    }
+
+    #[test]
     fn vacuum_table() {
         let input = vec![
                 Token::Vacuum,

--- a/src/parser/alter.rs
+++ b/src/parser/alter.rs
@@ -76,7 +76,7 @@ where
         Some(Token::Constraint) => {
             let (column_name, constraint) = parse_column_constraint(&mut token)?;
             Ok(Command::AddColumnConstraint { table_name, column_name, constraint })
-        }
+        },
         None => Err(ParserError::AddTypeMissing),
         Some(token) => Err(ParserError::AddTypeUnknown(token, "COLUMN")),
     }

--- a/src/parser/alter.rs
+++ b/src/parser/alter.rs
@@ -123,6 +123,10 @@ where
             let column_name = parse_column_name(token)?;
             Ok(Command::DropTableColumn { table_name, column_name })
         },
+        Some(Token::Constraint) => {
+            let (column_name, constraint) = parse_column_constraint(&mut token)?;
+            Ok(Command::DropColumnConstraint { table_name, column_name, constraint })
+        }
         None => Err(ParserError::DropTypeMissing),
         Some(token) => Err(ParserError::DropTypeUnknown(token, "COLUMN")),
     }

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -14,6 +14,8 @@ pub enum ParserError<'a> {
     CreateTypeUnknown(&'a Token),
     DropTypeMissing,
     DropTypeUnknown(&'a Token, &'static str),
+    AddTypeMissing,
+    AddTypeUnknown(&'a Token, &'static str),
     AlterTypeMissing,
     AlterTypeUnknown(&'a Token),
     AlterTableActionMissing,
@@ -58,6 +60,8 @@ pub enum ParserError<'a> {
     FromMissing,
     LexerError(LexerError),
     InvalidConstraint(Vec<&'a Token>),
+    NoConstraintsGiven,
+    MultipleConstraintsGiven,
     InvalidSchemaDefinition(String),
 }
 
@@ -77,6 +81,9 @@ impl<'a> fmt::Display for ParserError<'a> {
             Self::DropTypeMissing => "DROP type is not provided".to_string(),
             Self::DropTypeUnknown(drop_type, considered) =>
                 format!("unknown DROP type '{}', consider using DROP {}", drop_type, considered),
+            Self::AddTypeMissing => "ADD type is not provided".to_string(),
+            Self::AddTypeUnknown(drop_type, considered) =>
+                format!("unknown ADD type '{}', consider using DROP {}", drop_type, considered),
             Self::AlterTypeMissing => "ALTER type is not provided".to_string(),
             Self::AlterTypeUnknown(alter_type) =>
                 format!("unknown ALTER type '{}', consider using ALTER TABLE", alter_type),
@@ -129,6 +136,8 @@ impl<'a> fmt::Display for ParserError<'a> {
             Self::FromExpected(token) => format!("expected FROM keyword, got {}", token),
             Self::FromMissing => "expected FROM keyword, got nothing".to_string(),
             Self::LexerError(lexer_error) => format!("{}", lexer_error),
+            Self::MultipleConstraintsGiven => "only one constraint is allowed, but several were given".to_string(),
+            Self::NoConstraintsGiven => "no constraints were given".to_string(),
             Self::InvalidConstraint(tokens) =>
                 format!("cannot treat constraint sequence '{:?}'",
                         tokens.iter().map(|t| t.to_string()).collect::<Vec<String>>()),

--- a/src/parser/shared.rs
+++ b/src/parser/shared.rs
@@ -100,7 +100,7 @@ where
     }
 }
 
-fn parse_constraint_tokens(tokens: Vec<&Token>) -> Result<Vec<Constraint>, ParserError> {
+pub fn parse_constraint_tokens(tokens: Vec<&Token>) -> Result<Vec<Constraint>, ParserError> {
     let mut iter = tokens.iter();
     let mut result = vec![];
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -224,7 +224,6 @@ impl Table {
             },
             Some(index) => {
                 column_constraints.swap_remove(index);
-                ()
             },
         }
 

--- a/src/table/error.rs
+++ b/src/table/error.rs
@@ -22,6 +22,8 @@ pub enum TableError {
     CannotDeleteRow(PagerError),
     CmpError(CmpError),
     VacuumFailed(PagerError),
+    ConstraintAlreadyExists { table_name: String, column_name: String, constraint: Constraint },
+    ConstraintNotExists { table_name: String, column_name: String, constraint: Constraint },
     ConstraintViolation { table_name: String, constraint: Constraint, column_name: String, value: SqlValue },
 }
 
@@ -45,6 +47,10 @@ impl fmt::Display for TableError {
             Self::CannotDeleteRow(_pager_error) => write!(f, "cannot delete row in the table"),
             Self::CmpError(cmp_error) => write!(f, "{}", cmp_error),
             Self::VacuumFailed(_pager_error) => write!(f, "failed to vaccum table"),
+            Self::ConstraintAlreadyExists { table_name, column_name, constraint } =>
+                write!(f, "table's '{}' column '{}' already has constraint '{}'", table_name, column_name, constraint),
+            Self::ConstraintNotExists { table_name, column_name, constraint } =>
+                write!(f, "table's '{}' column '{}' does not have constraint '{}'", table_name, column_name, constraint),
             Self::ConstraintViolation { table_name, constraint, column_name, value } =>
                 write!(f,
                     "value {} violates '{}' constraint on column '{}' from table '{}'",


### PR DESCRIPTION
- allow to use `ALTER TABLE users ADD CONSTRAINT NOT NULL (id)`;
- allow to use `ALTER TABLE users DROP CONSTRAINT NOT NULL (id)`;
- change alter column name syntax from `ALTER TABLE users ADD age int` to `ALTER TABLE users ADD COLUMN age int`.