### PR TITLE
Change parsing rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "yarrd"
-version = "0.2.3"
+version = "0.2.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarrd"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ yarrd> insert into users (name, id) values ("john", 3)
 
 yarrd> insert into users (id, name) values (1, NULL)
 
-yarrd> select id from users where name = john
+yarrd> select id from users where name = "john"
 ```
 
 result is:
@@ -206,7 +206,7 @@ Supported constraints: `NOT NULL`, `DEFAULT`.
 - ✓ allow to update constraints
 - ✓ implement default constraint
 - ✓ implement check constraint
-- `SELECT id FROM users WHERE "users.name" = name` should not return all records
+- ✓ `SELECT id FROM users WHERE "users.name" = name` should not return all records
 - implement create index
   - store hashtable for primary keys at the beginning of file or store those in root database file
   - update hashtable on insert

--- a/src/binary_condition.rs
+++ b/src/binary_condition.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use crate::lexer::SqlValue;
 use crate::cmp_operator::CmpOperator;
 use crate::row_check::{RowCheck, RowCheckValue};
+use crate::table::error::TableError;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct BinaryCondition {
@@ -18,42 +19,57 @@ impl fmt::Display for BinaryCondition {
 }
 
 impl BinaryCondition {
-    pub fn compile(self, table_name: &str, column_names: &[String]) -> RowCheck {
-        let left = Self::build_row_check_value(self.left_value, table_name, column_names);
-        let right = Self::build_row_check_value(self.right_value, table_name, column_names);
+    pub fn compile(self, table_name: &str, column_names: &[String]) -> Result<RowCheck, TableError> {
+        let left = Self::build_row_check_value(self.left_value, table_name, column_names)?;
+        let right = Self::build_row_check_value(self.right_value, table_name, column_names)?;
 
-        RowCheck {
-            operator: self.operator,
-            left,
-            right,
-        }
+        Ok(
+            RowCheck {
+                operator: self.operator,
+                left,
+                right,
+            }
+        )
     }
 
-    pub fn build_row_check_value(value: SqlValue, table_name: &str, column_names: &[String]) -> RowCheckValue {
-        let string_value = value.to_string();
-        let splitted_identificator: Vec<&str> = string_value.split('.').collect();
-        match splitted_identificator.len() {
-            1 => {
-                let index = column_names.iter()
-                    .position(|table_column_name| table_column_name.eq(&string_value));
-                match index {
-                    None => RowCheckValue::Static(value),
-                    Some(i) => RowCheckValue::TableColumn(i),
+    pub fn build_row_check_value(value: SqlValue, table_name: &str, column_names: &[String]) -> Result<RowCheckValue, TableError> {
+        match value {
+            SqlValue::Identificator(column_string) => {
+                let splitted_identificator: Vec<&str> = column_string.splitn(2, '.').collect();
+                match splitted_identificator.len() {
+                    1 => {
+                        let index = column_names.iter()
+                            .position(|table_column_name| table_column_name.eq(&column_string));
+                        match index {
+                            None => Err(TableError::ColumnNotExist {
+                                table_name: table_name.to_string(),
+                                column_name: column_string
+                            }),
+                            Some(i) => Ok(RowCheckValue::TableColumn(i)),
+                        }
+                    },
+                    2 => {
+                        if !splitted_identificator[0].eq(table_name) {
+                            Err(TableError::TableNotExist(table_name.to_string()))
+                        } else {
+                            let index = column_names.iter()
+                                .position(|table_column_name| table_column_name.eq(splitted_identificator[1]));
+                            match index {
+                                None => Err(TableError::ColumnNotExist {
+                                    table_name: table_name.to_string(),
+                                    column_name: splitted_identificator[1].to_string()
+                                }),
+                                Some(i) => Ok(RowCheckValue::TableColumn(i)),
+                            }
+                        }
+                    },
+                    _ => Err(TableError::UnexpectedBinaryConditionError {
+                        table_name: table_name.to_string(),
+                        column_string: column_string.to_string()
+                    })
                 }
             },
-            2 => {
-                if !splitted_identificator[0].eq(table_name) {
-                    RowCheckValue::Static(value)
-                } else {
-                    let index = column_names.iter()
-                        .position(|table_column_name| table_column_name.eq(splitted_identificator[1]));
-                    match index {
-                        None => RowCheckValue::Static(value),
-                        Some(i) => RowCheckValue::TableColumn(i),
-                    }
-                }
-            },
-            _ => RowCheckValue::Static(value),
+            _ => Ok(RowCheckValue::Static(value)),
         }
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -140,7 +140,7 @@ mod tests {
     fn insert_with_constraints_and_select_from_table() {
         let (_db_file, mut database) = open_test_database();
         let id_greater_than_zero = BinaryCondition {
-            left_value: SqlValue::String("id".to_string()),
+            left_value: SqlValue::Identificator("id".to_string()),
             operator: CmpOperator::Greater,
             right_value: SqlValue::Integer(0)
         };
@@ -195,7 +195,7 @@ mod tests {
             column_names: vec![SelectColumnName::AllColumns, SelectColumnName::Name(SqlValue::Identificator("id".to_string()))],
             where_clause: Some(BinaryCondition {
                 left_value: SqlValue::Integer(1),
-                right_value: SqlValue::String("users.id".to_string()),
+                right_value: SqlValue::Identificator("users.id".to_string()),
                 operator: CmpOperator::Equals,
             }),
         };
@@ -289,7 +289,7 @@ mod tests {
 
         let insert_into_table = Command::InsertInto {
             table_name: SqlValue::Identificator("users".to_string()),
-            column_names: Some(vec![SqlValue::Identificator("id".to_string()), SqlValue::String("name".to_string())]),
+            column_names: Some(vec![SqlValue::Identificator("id".to_string()), SqlValue::Identificator("name".to_string())]),
             values: vec![SqlValue::Integer(1), SqlValue::Identificator("John".to_string())],
         };
         let insert_into_table_result = database.execute(insert_into_table);
@@ -299,7 +299,7 @@ mod tests {
             table_name: SqlValue::Identificator("users".to_string()),
             where_clause: Some(BinaryCondition {
                 left_value: SqlValue::String("John".to_string()),
-                right_value: SqlValue::String("name".to_string()),
+                right_value: SqlValue::Identificator("name".to_string()),
                 operator: CmpOperator::Equals,
             }),
         };
@@ -478,7 +478,7 @@ mod tests {
         let delete_from_table = Command::Delete {
             table_name: SqlValue::Identificator("users".to_string()),
             where_clause: Some(BinaryCondition {
-                left_value: SqlValue::String("id".to_string()),
+                left_value: SqlValue::Identificator("id".to_string()),
                 right_value: SqlValue::Integer(1),
                 operator: CmpOperator::Equals,
             }),
@@ -496,7 +496,7 @@ mod tests {
         let delete_from_table = Command::Delete {
             table_name: SqlValue::Identificator("users".to_string()),
             where_clause: Some(BinaryCondition {
-                left_value: SqlValue::String("id".to_string()),
+                left_value: SqlValue::Identificator("id".to_string()),
                 right_value: SqlValue::Integer(15),
                 operator: CmpOperator::LessEquals,
             }),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -232,7 +232,7 @@ fn parse_sql_value(str_token: &str) -> Option<SqlValue> {
         Some(SqlValue::Integer(integer))
     } else if let Ok(float) = str_token.parse::<f64>() {
         Some(SqlValue::Float(float))
-    } else if str_token.chars().all(|c| c.is_alphanumeric() || c == '_') {
+    } else if str_token.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '.') {
         Some(SqlValue::Identificator(str_token.to_string()))
     } else {
         None

--- a/src/table/error.rs
+++ b/src/table/error.rs
@@ -12,6 +12,7 @@ use crate::row_check::RowCheck;
 
 #[derive(Debug)]
 pub enum TableError {
+    TableNotExist(String),
     CreateError(PagerError),
     ColumnNotExist { table_name: String, column_name: String },
     ColumnNthNotExist { table_name: String, column_index: usize },
@@ -28,11 +29,13 @@ pub enum TableError {
     ConstraintNotExists { table_name: String, column_name: String, constraint: Constraint },
     ColumnConstraintViolation { table_name: String, constraint: Constraint, column_name: String, value: SqlValue },
     CheckViolation { table_name: String, row_check: RowCheck, row: Row },
+    UnexpectedBinaryConditionError { table_name: String, column_string: String },
 }
 
 impl fmt::Display for TableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            Self::TableNotExist(table_name) => write!(f, "table '{}' not exists", table_name),
             Self::CreateError(_pager_error) => write!(f, "unable to create table: error initializing a pager"),
             Self::ColumnNotExist { table_name, column_name } =>
                 write!(f, "table '{}' does not have column '{}'", table_name, column_name),
@@ -62,6 +65,10 @@ impl fmt::Display for TableError {
                 write!(f,
                     "row {} violates 'check ({})' constraint from table '{}'",
                     row, row_check, table_name),
+            Self::UnexpectedBinaryConditionError { table_name, column_string } =>
+                write!(f,
+                    "unexpected error while building binary condition value from table '{}' and table column '{}'",
+                    table_name, column_string),
         }
     }
 }


### PR DESCRIPTION
`SELECT id FROM users WHERE "users.name" = name` previously would return all records, because it was treating `name` as a "name" column on table "users".
From now on, everything in quoutes considered to be a static value, and everything without quotes considered to be a column name (with or without table name). That means that `SELECT id FROM users WHERE name = john` will no longer work, one have to put `john` in quotes, like `"john"`.