### PR TITLE
chore: reindex on vacuum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "yarrd"
-version = "0.3.1"
+version = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarrd"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/hash_index.rs
+++ b/src/hash_index.rs
@@ -117,6 +117,12 @@ impl HashIndex {
         }
     }
 
+    pub fn clear(&mut self) -> Result<(), HashIndexError> {
+        self.hash_index_file.set_len(0)?;
+        self.hash_index_file.rewind()?;
+        Ok(())
+    }
+
     pub fn increase_buckets_count(&mut self) -> Result<(), HashIndexError> {
         let mut swap_hash_index_file = OpenOptions::new()
             .write(true)

--- a/src/table.rs
+++ b/src/table.rs
@@ -398,7 +398,40 @@ impl Table {
     }
 
     pub fn vacuum(&mut self) -> Result<(), TableError> {
-        self.pager.vacuum().map_err(TableError::VacuumFailed)
+        self.pager.vacuum().map_err(TableError::VacuumFailed)?;
+        self.reindex()
+    }
+
+    fn reindex(&mut self) -> Result<(), TableError> {
+        let mut enumerated_column_indexes: Vec<(usize, &mut HashIndex)> = self.column_indexes
+            .iter_mut()
+            .enumerate()
+            .filter(|(_i, column_index_option)| column_index_option.is_some())
+            .map(|(i, column_index_option)| (i, column_index_option.as_mut().unwrap()))
+            .collect();
+
+        enumerated_column_indexes.iter_mut()
+            .map(|(_i, column_index)| column_index.clear().map_err(TableError::HashIndexError))
+            .collect::<Result<(), TableError>>()?;
+
+        Self::seq_scan(&mut self.pager)
+            .map(|scan_result| {
+                let scan_product = scan_result?;
+                //for (column_number, column_index) in enumerated_column_indexes {
+                enumerated_column_indexes
+                    .iter_mut()
+                    .map(|(column_number, column_index)| {
+                        let value = scan_product
+                            .row
+                            .get_cell_sql_value(&self.headers.column_types, *column_number)
+                            .map_err(TableError::CannotGetCell)?;
+
+                        column_index.insert_row(&value, scan_product.row_id, self.row_count)
+                            .map_err(TableError::HashIndexError)
+                    })
+                .collect::<Result<(), TableError>>()
+            })
+            .collect::<Result<(), TableError>>()
     }
 
     fn matching_rows<'a>(pager: &'a mut Pager, column_indexes: &'a Vec<Option<HashIndex>>,

--- a/src/table.rs
+++ b/src/table.rs
@@ -417,7 +417,6 @@ impl Table {
         Self::seq_scan(&mut self.pager)
             .map(|scan_result| {
                 let scan_product = scan_result?;
-                //for (column_number, column_index) in enumerated_column_indexes {
                 enumerated_column_indexes
                     .iter_mut()
                     .map(|(column_number, column_index)| {


### PR DESCRIPTION
whenever we call `vacuum`, we need to update index. As it is likely to touch a lot of rows, it is reasonable to recreate index from scratch instead of updating index row-by-row.