### PR TITLE
Alter table index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "yarrd"
-version = "0.4.2"
+version = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarrd"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Supported constraints: `NOT NULL`, `DEFAULT`.
   - ✓ update hashtable on vacuum
   - ✓ allow to create index on table, save index in schema
   - ✓ allow to drop index on table and drop indexes on drop table
-  - adjust index on alter table (rename table, rename column, drop column, add column)
+  - ✓ adjust index on alter table (rename table, rename column, drop column, add column)
   - implement REINDEX
 - do not allow two columns with the same names in a table
 - implement unique constraint
@@ -225,6 +225,7 @@ Supported constraints: `NOT NULL`, `DEFAULT`.
 - implement primary constraint and use row_id if not set
 - think if we should rename 'validate_row_over_constraint' to smth like "check_not_null_constraints"
 - check if we can avoid generating byte layout for every row when using where
+- think if there is a way to dry command full tests
 - introduce NOT
 - dry parser 'parse_index_name', 'parse_column_name' etc, since those differ only be error messages
 - remove tables dir if it is empty after tables cleanup

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Supported constraints: `NOT NULL`, `DEFAULT`.
   - ✓ update hashtable on vacuum
   - ✓ allow to create index on table, save index in schema
   - ✓ allow to drop index on table and drop indexes on drop table
-  - adjust index on alter table
+  - adjust index on alter table (rename table, rename column, drop column, add column)
   - implement REINDEX
 - do not allow two columns with the same names in a table
 - implement unique constraint

--- a/src/command.rs
+++ b/src/command.rs
@@ -483,7 +483,45 @@ mod tests {
             column_name: SqlValue::String("name".to_string()),
         };
         database.execute(drop_table_column).expect("drop table should be successful");
-        assert!(Some(1).ok_or(0).is_ok());
+    }
+
+    #[test]
+    fn create_table_with_index_and_add_column() {
+        let (_db_file, mut database) = open_test_database();
+        let create_table = Command::CreateTable {
+            table_name: SqlValue::Identificator("users".to_string()),
+            columns: vec![
+                ColumnDefinition {
+                    name: SqlValue::Identificator("id".to_string()),
+                    kind: ColumnType::Integer,
+                    column_constraints: vec![],
+                },
+                ColumnDefinition {
+                    name: SqlValue::Identificator("name".to_string()),
+                    kind: ColumnType::String,
+                    column_constraints: vec![],
+                },
+            ],
+        };
+
+        database.execute(create_table).expect("database create table statement should be successful");
+
+        let create_index = Command::CreateIndex {
+            table_name: SqlValue::Identificator("users".to_string()),
+            index_name: SqlValue::Identificator("users-id".to_string()),
+            column_name: SqlValue::Identificator("name".to_string()),
+        };
+        database.execute(create_index).expect("database create index statement should be successful");
+
+        let add_table_column = Command::AddTableColumn {
+            table_name: SqlValue::Identificator("users".to_string()),
+            column_definition: ColumnDefinition {
+                name: SqlValue::String("age".to_string()),
+                kind: ColumnType::Integer,
+                column_constraints: vec![],
+            },
+        };
+        database.execute(add_table_column).expect("add table should be successful");
     }
 
     #[test]

--- a/src/command.rs
+++ b/src/command.rs
@@ -451,6 +451,42 @@ mod tests {
     }
 
     #[test]
+    fn create_table_with_index_and_drop_column() {
+        let (_db_file, mut database) = open_test_database();
+        let create_table = Command::CreateTable {
+            table_name: SqlValue::Identificator("users".to_string()),
+            columns: vec![
+                ColumnDefinition {
+                    name: SqlValue::Identificator("id".to_string()),
+                    kind: ColumnType::Integer,
+                    column_constraints: vec![],
+                },
+                ColumnDefinition {
+                    name: SqlValue::Identificator("name".to_string()),
+                    kind: ColumnType::String,
+                    column_constraints: vec![],
+                },
+            ],
+        };
+
+        database.execute(create_table).expect("database create table statement should be successful");
+
+        let create_index = Command::CreateIndex {
+            table_name: SqlValue::Identificator("users".to_string()),
+            index_name: SqlValue::Identificator("users-id".to_string()),
+            column_name: SqlValue::Identificator("name".to_string()),
+        };
+        database.execute(create_index).expect("database create index statement should be successful");
+
+        let drop_table_column = Command::DropTableColumn {
+            table_name: SqlValue::Identificator("users".to_string()),
+            column_name: SqlValue::String("name".to_string()),
+        };
+        database.execute(drop_table_column).expect("drop table should be successful");
+        assert!(Some(1).ok_or(0).is_ok());
+    }
+
+    #[test]
     fn create_table_insert_delete_and_vacuum() {
         let (db_file, mut database) = open_test_database();
         let create_table = Command::CreateTable {

--- a/src/database.rs
+++ b/src/database.rs
@@ -244,21 +244,18 @@ impl Database {
     fn rename_table(&mut self, table_name: SqlValue, new_table_name: SqlValue) -> Result<Option<QueryResult>, ExecutionError> {
         let table_name_string = table_name.to_string();
         let new_table_name_string = new_table_name.to_string();
-        let table_filepath = Self::table_filepath(self.tables_dir.as_path(), table_name_string.as_str());
         let new_table_filepath = Self::table_filepath(self.tables_dir.as_path(), new_table_name_string.as_str());
 
         let mut table = match self.tables.remove(table_name_string.as_str()) {
             None => return Err(ExecutionError::TableNotExist(table_name_string)),
             Some(table) => table,
         };
-
-        match fs::rename(table_filepath, new_table_filepath) {
+        match table.rename(&new_table_name_string, new_table_filepath.as_path()) {
             Err(io_error) => {
                 self.tables.insert(table_name_string, table);
                 Err(io_error.into())
             },
             Ok(_) => {
-                table.set_name(&new_table_name_string);
                 self.tables.insert(new_table_name_string, table);
                 Ok(None)
             }

--- a/src/database.rs
+++ b/src/database.rs
@@ -176,28 +176,6 @@ impl Database {
         let table = self.build_table(&table_name_string, &columns)?;
         self.tables.insert(table_name_string, table);
         Ok(None)
-        //let table_filepath = Self::table_filepath(self.tables_dir.as_path(), table_name_string.as_str());
-
-        //if self.tables.contains_key(table_name_string.as_str()) {
-        //    return Err(ExecutionError::TableAlreadyExist(table_name_string));
-        //}
-
-        //File::create(table_filepath.as_path())?;
-        //match Table::new(table_filepath.clone(), table_name_string.as_str(), 0, columns, vec![]) {
-        //    Ok(table) => {
-        //        self.tables.insert(table_name_string, table);
-        //        Ok(None)
-        //    },
-        //    Err(create_table_error) => {
-        //        fs::remove_file(table_filepath.as_path())
-        //            .unwrap_or_else(|_| panic!(
-        //                        "failed to create table: {}, failed to remove table file '{}', try to remove it manually",
-        //                        create_table_error, table_filepath.to_str().unwrap()
-        //                    ));
-
-        //        Err(create_table_error.into())
-        //    }
-        //}
     }
 
     fn build_table(&self, table_name: &str, columns: &Vec<ColumnDefinition>) -> Result<Table, ExecutionError> {
@@ -220,11 +198,6 @@ impl Database {
             }
         }
     }
-
-    //fn save_empty_table_to_database(&mut self, table_name: &str) -> Result<(), ExecutionError> {
-    //    self.tables.insert(table_name.to_string(), table);
-    //    Ok(())
-    //}
 
     fn drop_table(&mut self, table_name: SqlValue) -> Result<Option<QueryResult>, ExecutionError> {
         let table_name_string = table_name.to_string();
@@ -331,8 +304,6 @@ impl Database {
         let table_column_types = table.column_types().to_vec();
         new_column_definitions.push(column_definition);
         let temp_new_table_name = Self::temporary_table_name(&table_name);
-        // TODO copy indexes
-        //self.create_table(temp_new_table_name.clone(), new_column_definitions)?;
         let mut new_table = self.build_table(&temp_new_table_name.to_string(), &new_column_definitions)?;
         table.clone_indexes_to(&mut new_table)?;
         self.tables.insert(temp_new_table_name.to_string(), new_table);

--- a/src/hash_index.rs
+++ b/src/hash_index.rs
@@ -22,9 +22,9 @@ pub struct HashIndex {
 }
 
 impl HashIndex {
-    pub fn new(tables_dir: &Path, table_name: &str, name: String, column_number: usize) -> Result<HashIndex, HashIndexError> {
-        let hash_index_filepath = Self::build_hash_index_filepath(tables_dir, table_name, column_number);
-        let swap_filepath = Self::build_swap_hash_index_filepath(tables_dir, table_name, column_number);
+    pub fn new(tables_dir: &Path, table_name: &str, name: String) -> Result<HashIndex, HashIndexError> {
+        let hash_index_filepath = Self::build_hash_index_filepath(tables_dir, table_name, name.as_str());
+        let swap_filepath = Self::build_swap_hash_index_filepath(tables_dir, table_name, name.as_str());
 
         let hash_index_file = OpenOptions::new()
             .read(true)
@@ -93,6 +93,19 @@ impl HashIndex {
     pub fn destroy(self) -> Result<(), HashIndexError> {
         fs::remove_file(self.swap_hash_index_filepath)?;
         fs::remove_file(self.hash_index_filepath)?;
+        Ok(())
+    }
+
+    pub fn adjust_filepaths(&mut self, new_table_name: &str, tables_dir: &Path) -> Result<(), HashIndexError> {
+        let new_hash_index_filepath = Self::build_hash_index_filepath(tables_dir, new_table_name, &self.name);
+        let new_swap_filepath = Self::build_swap_hash_index_filepath(tables_dir, new_table_name, &self.name);
+
+        // TODO: this should be rollbackable via cascade file manager
+        fs::rename(self.hash_index_filepath.as_path(), new_hash_index_filepath.as_path())?;
+        fs::remove_file(self.swap_hash_index_filepath.as_path())?;
+        self.hash_index_filepath = new_hash_index_filepath;
+        self.swap_hash_index_filepath = new_swap_filepath;
+
         Ok(())
     }
 
@@ -196,16 +209,15 @@ impl HashIndex {
         hasher.finish()
     }
 
-    // TODO: maybe use index name instead?
-    fn build_hash_index_filepath(tables_dir: &Path, table_name: &str, column_number: usize) -> PathBuf {
+    fn build_hash_index_filepath(tables_dir: &Path, table_name: &str, index_name: &str) -> PathBuf {
         let mut filepath = tables_dir.to_path_buf();
-        filepath.push(format!("{}-{}.hash", table_name, column_number));
+        filepath.push(format!("{}-{}.hash", table_name, index_name));
         filepath
     }
 
-    fn build_swap_hash_index_filepath(tables_dir: &Path, table_name: &str, column_number: usize) -> PathBuf {
+    fn build_swap_hash_index_filepath(tables_dir: &Path, table_name: &str, index_name: &str) -> PathBuf {
         let mut filepath = tables_dir.to_path_buf();
-        filepath.push(format!("{}-{}-swap.hash", table_name, column_number));
+        filepath.push(format!("{}-{}-swap.hash", table_name, index_name));
         filepath
     }
 }
@@ -221,8 +233,8 @@ mod tests {
         s.finish()
     }
 
-    fn create_index_file(table_name: &str, column_number: usize) -> (TempFile, PathBuf) {
-        let index_file = TempFile::new(format!("{}-{}.hash", table_name, column_number).as_str()).unwrap();
+    fn create_index_file(table_name: &str, index_name: &str) -> (TempFile, PathBuf) {
+        let index_file = TempFile::new(format!("{}-{}.hash", table_name, index_name).as_str()).unwrap();
         let table_file_name = "users.table";
         let mut tables_dir_path = index_file.path().to_path_buf();
         tables_dir_path.pop();
@@ -232,13 +244,13 @@ mod tests {
 
     #[test]
     fn create_index_does_not_panic() {
-        let (_index_file, tables_dir_path) = create_index_file("users", 8);
-        HashIndex::new(&tables_dir_path, "users", "name".to_string(), 8).expect("cannot create index from file");
+        let (_index_file, tables_dir_path) = create_index_file("users", "u8");
+        HashIndex::new(&tables_dir_path, "users", "name".to_string()).expect("cannot create index from file");
     }
 
     #[test]
     fn find_row_ids() {
-        let (index_file, tables_dir_path) = create_index_file("users", 2);
+        let (index_file, tables_dir_path) = create_index_file("users", "u_index_2");
 
         let hash_1 = calculate_hash(&1i64).to_le_bytes();
         let hash_john = calculate_hash(&"john").to_le_bytes();
@@ -263,7 +275,7 @@ mod tests {
         index_file.write_bytes(&contents)
             .expect("seed contents should be writable to index file");
 
-        let index = HashIndex::new(tables_dir_path.as_path(), "users", "i_name".to_string(), 2)
+        let index = HashIndex::new(tables_dir_path.as_path(), "users", "u_index_2".to_string())
             .expect("hash index should be creatable from seed file");
 
         assert_eq!(index.find_row_ids(&SqlValue::Integer(1)).next().unwrap().unwrap(), 3u64);
@@ -273,7 +285,7 @@ mod tests {
 
     #[test]
     fn insert_row_causing_overflow() {
-        let (index_file, tables_dir_path) = create_index_file("users", 2);
+        let (index_file, tables_dir_path) = create_index_file("users", "i_name");
 
         let hash_5 = calculate_hash(&5i64).to_le_bytes(); // in case of 4 buckets, hash of 5 falls to first bucket
         let mut contents: Vec<u8> = vec![];
@@ -290,7 +302,7 @@ mod tests {
         index_file.write_bytes(&contents)
             .expect("seed contents should be writable to index file");
 
-        let mut index = HashIndex::new(tables_dir_path.as_path(), "users", "i_name".to_string(), 2)
+        let mut index = HashIndex::new(tables_dir_path.as_path(), "users", "i_name".to_string())
             .expect("hash index should be creatable from seed file");
 
         assert_eq!(index.insert_row(&SqlValue::Integer(5), 999, 28).is_ok(), true);
@@ -309,7 +321,7 @@ mod tests {
 
     #[test]
     fn insert_row_causing_index_recreation() {
-        let (index_file, tables_dir_path) = create_index_file("users", 2);
+        let (index_file, tables_dir_path) = create_index_file("users", "u2");
 
         let hash_1 = calculate_hash(&1i64).to_le_bytes();
         let mut contents: Vec<u8> = vec![];
@@ -326,7 +338,7 @@ mod tests {
         index_file.write_bytes(&contents)
             .expect("seed contents should be writable to index file");
 
-        let mut index = HashIndex::new(tables_dir_path.as_path(), "users", "users-2-i".to_string(), 2)
+        let mut index = HashIndex::new(tables_dir_path.as_path(), "users", "u2".to_string())
             .expect("hash index should be creatable from seed file");
 
         assert_eq!(index.insert_row(&SqlValue::Integer(1), 999, 28).is_ok(), true);
@@ -341,7 +353,7 @@ mod tests {
 
     #[test]
     fn update_and_delete_row() {
-        let (index_file, tables_dir_path) = create_index_file("users", 1);
+        let (index_file, tables_dir_path) = create_index_file("users", "ui1");
 
         let hash_1 = calculate_hash(&1i64).to_le_bytes();
         let mut contents: Vec<u8> = vec![];
@@ -358,7 +370,7 @@ mod tests {
         index_file.write_bytes(&contents)
             .expect("seed contents should be writable to index file");
 
-        let index = HashIndex::new(tables_dir_path.as_path(), "users", "users_1_i".to_string(), 1)
+        let index = HashIndex::new(tables_dir_path.as_path(), "users", "ui1".to_string())
             .expect("hash index should be creatable from seed file");
 
         assert_eq!(index.update_row(1, &SqlValue::Integer(1), &SqlValue::Integer(3)).is_ok(), true);

--- a/src/table.rs
+++ b/src/table.rs
@@ -111,7 +111,7 @@ impl Table {
                 Some(HashIndex::new(tables_dir, name, index_name)?);
         }
 
-        for (i, column_definition) in column_definitions.into_iter().enumerate() {
+        for (i, column_definition) in column_definitions.iter().enumerate() {
             column_names.push(column_definition.name.to_string());
             column_types.push(column_definition.kind);
 


### PR DESCRIPTION
`ALTER TABLE` statements now care about existing indexes instead of dropping those